### PR TITLE
feat: add method for checking if a term is empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sikula"
-version = "0.4.0-alpha.5"
+version = "0.4.0-alpha.6"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jens Reimann <jreimann@redhat.com>"]

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -267,6 +267,15 @@ where
             _ => self,
         }
     }
+
+    /// Returns true if there are no terms
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::And(terms) if terms.is_empty() => true,
+            Self::Or(terms) if terms.is_empty() => true,
+            _ => false,
+        }
+    }
 }
 
 /// A combination of search terms and sorting.

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -307,3 +307,16 @@ fn test_compaction() {
         ])
     );
 }
+
+#[test]
+fn test_empty_query() {
+    let mut r = ManualResource::parse("message:a").unwrap();
+    assert!(!r.term.is_empty());
+    r.term = r.term.compact();
+    assert!(!r.term.is_empty());
+
+    let mut r = ManualResource::parse("sort:size").unwrap();
+    assert!(r.term.is_empty());
+    r.term = r.term.compact();
+    assert!(r.term.is_empty());
+}


### PR DESCRIPTION
This can happen if no query was specified or if only sorting order was specified.